### PR TITLE
Create basic test for JUnit functionality.

### DIFF
--- a/src/test/java/com/gitrekt/resort/TestGitRekt.java
+++ b/src/test/java/com/gitrekt/resort/TestGitRekt.java
@@ -1,0 +1,29 @@
+package com.gitrekt.resort;
+
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * This class is here just to test the basic functionality of JUnit in our 
+ * application. It should be removed as we get further into production, but for
+ * now, it is a good way to make sure JUnit is working properly.
+ */
+public class TestGitRekt {
+    
+    // TODO: Remove temporary tests, add real tests.
+    
+    @Test
+    public void testJUnitWorking() {
+        int i = 1;
+        assertNotNull("Something is very, very wrong.", i);
+    }
+    
+    @Ignore
+    @Test
+    public void testJUnitTestFailure() {
+        int i = 1;
+        assertNotEquals("JUnit test is failing properly", i, 1);
+    }
+}


### PR DESCRIPTION
This should be removed at a later date, but for now, it is a good way to
verify that JUnit is working. The failing test has been given an ignore
annotation, for obvious reasons.