### PR TITLE
Fix application startup time with Hibernate

### DIFF
--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -40,7 +40,13 @@ http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
             <property name="hibernate.hbm2ddl.auto" value="create"/>
             
             <property name="hibernate.connection.pool_size" value="1"/>
-        
+            
+            <property name="hibernate.dialect" 
+                      value="org.hibernate.dialect.PostgreSQLDialect"/>
+            
+            <property name="hibernate.temp.use_jdbc_metadata_defaults" 
+                      value="false"/>
+            
         </properties>
         
     </persistence-unit>


### PR DESCRIPTION
It turns out the bug was caused by Hibernate having to generate
a ton of metadata, rather than using the defaults. The problem
specifically seems to impact PostgreSQL databases (like ours) most.

The fix was simply to add a couple of configuration properties for
hibernate to the persistence.xml file.

Application startup time has now decreased from 36 seconds to
less than 2 seconds on my machine.

Fixes issue #126